### PR TITLE
Harden Hugo templates and guard CI build output

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Build (verbose)
         run: |
+          set -euo pipefail
           mkdir -p logs
           hugo --minify --verbose 2>&1 | tee logs/hugo-build.log
+          test -d public
 
       - name: Upload build log (if failed)
         if: failure()

--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,9 @@ languageCode = "zh-cn"
 title = "Kotlin 学习笔记（可运行）"
 theme = ""
 
+[params]
+  description = "记录 Kotlin 学习笔记"
+
 [pagination]
 pagerSize = 10
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,70 +1,81 @@
 {{/* layouts/_default/baseof.html */}}
 <!doctype html>
 <html lang="zh-CN">
-
-<head>
+  <head>
     <meta charset="utf-8">
     <title>{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ with .Description }}
+      <meta name="description" content="{{ . }}">
+    {{ else }}
+      {{ with .Site.Params.description }}
+        <meta name="description" content="{{ . }}">
+      {{ end }}
+    {{ end }}
     <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-            margin: 2rem;
-            line-height: 1.6;
-        }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        margin: 2rem;
+        line-height: 1.6;
+      }
 
-        header,
-        footer {
-            opacity: .85;
-            font-size: 0.95rem;
-        }
+      header,
+      footer {
+        opacity: .85;
+        font-size: 0.95rem;
+      }
 
-        pre {
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            padding: 1rem;
-            overflow: auto;
-        }
+      pre {
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 1rem;
+        overflow: auto;
+      }
 
-        code {
-            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-        }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      }
 
-        .container {
-            max-width: 860px;
-            margin: 0 auto;
-        }
+      .container {
+        max-width: 860px;
+        margin: 0 auto;
+      }
 
-        a {
-            color: #0b63ce;
-            text-decoration: none;
-        }
+      a {
+        color: #0b63ce;
+        text-decoration: none;
+      }
 
-        a:hover {
-            text-decoration: underline;
-        }
+      a:hover {
+        text-decoration: underline;
+      }
     </style>
-</head>
-
-<body>
+  </head>
+  <body>
     <div class="container">
-        <header>
-            <h1 style="margin-bottom:0.2rem">{{ .Site.Title }}</h1>
-            <div><a href="{{ " /" | relURL }}">首页</a></div>
-            <hr>
-        </header>
-
-        <main>
-            {{ block "main" . }}{{ end }}
-        </main>
-
+      <header>
+        <h1 style="margin-bottom:0.2rem">{{ .Site.Title }}</h1>
+        {{ with .Description }}
+          <p style="margin-top:0; color:#555;">{{ . }}</p>
+        {{ else }}
+          {{ with .Site.Params.description }}
+            <p style="margin-top:0; color:#555;">{{ . }}</p>
+          {{ end }}
+        {{ end }}
+        <div><a href="{{ "/" | relURL }}">首页</a></div>
         <hr>
-        <footer>
-            <p>由 Hugo 生成 · 支持 Kotlin Playground 可运行代码块</p>
-        </footer>
+      </header>
+
+      <main>
+        {{ block "main" . }}{{ end }}
+      </main>
+
+      <hr>
+      <footer>
+        <p>由 Hugo 生成 · 支持 Kotlin Playground 可运行代码块</p>
+      </footer>
     </div>
 
     {{ partial "kotlin-playground.html" . }}
-</body>
-
+  </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,31 @@
 {{ define "main" }}
   <h2>{{ .Title }}</h2>
-  <ul>
-    {{ range .Pages }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> <small>— {{ .Date.Format "2006-01-02" }}</small></li>
-    {{ else }}
-      <li>该栏目下还没有内容。</li>
-    {{ end }}
-  </ul>
+  {{- $pages := .Pages -}}
+  {{- if .IsHome -}}
+    {{- $pages = .Site.RegularPages -}}
+  {{- end -}}
+  {{- if not $pages -}}
+    {{- $pages = slice -}}
+  {{- end -}}
+  {{- $total := len $pages -}}
+  {{ if gt $total 0 }}
+    {{- $sorted := sort $pages "Date" "desc" -}}
+    <ul>
+      {{ range $sorted }}
+        <li>
+          <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+          {{ with .Date }}
+            <small>
+              <time datetime="{{ .Format "2006-01-02" }}">{{ .Format "2006-01-02" }}</time>
+            </small>
+          {{ end }}
+          {{ with .Summary }}
+            <div style="margin-top:0.25rem; color:#555;">{{ . }}</div>
+          {{ end }}
+        </li>
+      {{ end }}
+    </ul>
+  {{ else }}
+    <p>暂时还没有内容。</p>
+  {{ end }}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,21 @@
-{{/* layouts/_default/single.html */}}
 {{ define "main" }}
-<article>
+  <article>
     <h2>{{ .Title }}</h2>
-    {{ .Content }}
-</article>
+    {{ with .Date }}
+      <p><small><time datetime="{{ .Format "2006-01-02" }}">{{ .Format "2006-01-02" }}</time></small></p>
+    {{ end }}
+    <div>
+      {{ .Content }}
+    </div>
+  </article>
+  {{ if or .PrevInSection .NextInSection }}
+    <nav style="margin-top:2rem; display:flex; justify-content:space-between; font-size:0.9rem;">
+      <div>
+        {{ with .PrevInSection }}← <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>{{ end }}
+      </div>
+      <div>
+        {{ with .NextInSection }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a> →{{ end }}
+      </div>
+    </nav>
+  {{ end }}
 {{ end }}

--- a/layouts/partials/kotlin-playground.html
+++ b/layouts/partials/kotlin-playground.html
@@ -1,4 +1,8 @@
 {{/* layouts/partials/kotlin-playground.html */}}
-<script src="https://unpkg.com/kotlin-playground@1" data-selector="pre code.language-kotlin" data-theme="darcula"
-    data-auto-indent="true" data-min-compiler-version="1.9.0">
-    </script>
+<script
+  src="https://unpkg.com/kotlin-playground@1"
+  data-selector="pre code.language-kotlin"
+  data-theme="darcula"
+  data-auto-indent="true"
+  data-min-compiler-version="1.9.0"
+></script>


### PR DESCRIPTION
## Summary
- ensure the base layout and header description fall back cleanly to site metadata without relying on template `or`
- stabilize list and single templates by guarding empty collections, sorting explicitly, and only rendering navigation when neighbors exist
- tighten the GitHub Pages workflow to use `set -euo pipefail`, keep the Hugo log, and assert the `public` directory is created so builds fail fast when Hugo errors

## Testing
- not run (Hugo is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db4b9ffc9883218e3680a554c61fbc